### PR TITLE
explicitly require pthread for job_queue and enkf_fs tests

### DIFF
--- a/libenkf/tests/tests.cmake
+++ b/libenkf/tests/tests.cmake
@@ -98,7 +98,7 @@ target_link_libraries( enkf_main enkf  )
 add_test( enkf_main  ${EXECUTABLE_OUTPUT_PATH}/enkf_main )
 
 add_executable( enkf_fs enkf_fs.c )
-target_link_libraries( enkf_fs enkf  )
+target_link_libraries( enkf_fs enkf pthread )
 add_test( enkf_fs  ${EXECUTABLE_OUTPUT_PATH}/enkf_fs )
 
 add_executable( enkf_workflow_job_test_version enkf_workflow_job_test_version.c )

--- a/libjob_queue/tests/CMakeLists.txt
+++ b/libjob_queue/tests/CMakeLists.txt
@@ -8,7 +8,7 @@ add_executable( job_workflow_test job_workflow_test.c )
 add_executable( job_lsf_parse_bsub_stdout job_lsf_parse_bsub_stdout.c )
 add_executable( job_lsf_exclude_hosts_test job_lsf_exclude_hosts_test.c )
 
-target_link_libraries( job_status_test job_queue  )
+target_link_libraries( job_status_test job_queue pthread )
 target_link_libraries( job_workflow_test job_queue  )
 target_link_libraries( create_file job_queue   )
 target_link_libraries( job_loadOK job_queue   )


### PR DESCRIPTION
Fixes compilation issues on some systems of the form
```make
[ 85%] Linking C executable ../../bin/enkf_fs
/usr/bin/ld: CMakeFiles/enkf_fs.dir/enkf_fs.c.o: undefined reference to symbol 'pthread_mutexattr_init@@GLIBC_2.2.5'
/usr/lib64/libpthread.so.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make[2]: *** [bin/enkf_fs] Error 1
make[1]: *** [libenkf/tests/CMakeFiles/enkf_fs.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
```